### PR TITLE
Removed API key strings

### DIFF
--- a/myTracks/src/main/AndroidManifest.xml
+++ b/myTracks/src/main/AndroidManifest.xml
@@ -149,11 +149,11 @@ limitations under the License.
     <!-- For data backup -->
     <meta-data
       android:name="com.google.android.backup.api_key"
-      android:value="@string/backup_api_key" />
+      android:value="" />
     <!-- For map view v2 -->
     <meta-data
       android:name="com.google.android.maps.v2.API_KEY"
-      android:value="@string/maps_api_key" />
+      android:value="" />
     <!-- Activities -->
     <activity
       android:label="@string/menu_aggregated_statistics"


### PR DESCRIPTION
The compilation fails because the strings `backup_api_key` and `maps_api_key` are not included in the source. I just set them to empty strings, and didn't notice any problems. Let me know if there's a better solution to fix the build.

Edit: I just noticed that this is mentioned in the readme. Still, it would be good to make these keys optional, because F-Droid won't be able to build the app otherwise. And it makes it very complicated for new developers to compile the app.
